### PR TITLE
Add CODEOWNERS file to repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @mateusrodrigues and @haacked will be requested for
+# review when someone opens a pull request.
+*       @mateusrodrigues @haacked


### PR DESCRIPTION
Adding a CODEOWNERS file to the repository including present and past project contributors as code owners.